### PR TITLE
[84] Assign Crew Member To Event Orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -153,6 +153,9 @@ def dropoff
   end
 end
 
+def assign_order
+  
+end
 
 
   private

--- a/app/helpers/order_helper.rb
+++ b/app/helpers/order_helper.rb
@@ -23,6 +23,10 @@ module OrderHelper
     ]
   end
 
+  def crew_members(event)
+    event.account.users.where(permission_level: 2)
+  end
+
   def handle_order(order)
     if order.role == 'note'
       return order.update(status: 'verified', verified_by: current_user.id, assigned_to: current_user.id)
@@ -182,8 +186,7 @@ def product_data(transaction)
   return product
 end
 
-def create_order_message(order)
-  message_type = "order_#{order.status}"
+def create_order_message(order, message_type)
   puts "creating order message"
   message = order.messages.new(message_type: message_type, created_by: current_user.id, event_id: order.location.event.id, order_id: order.id, location_id: order.location_id)
   message.save

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -23,6 +23,8 @@ class Message < ApplicationRecord
       self.text = info + "#{order.role.upcase} Order #{order.id} verified by #{user_data(message.created_by)[:full_name]}"
     when 'order_canceled'
       self.text = info + "#{order.role.upcase} Order #{order.id} canceled by #{user_data(message.created_by)[:full_name]}"
+    when 'order_assigned'
+      self.text = info + "#{user_data(order.assigned_to)[:full_name]} has been assigned to: Order #{order.id}"
     when 'item_reserved'
       item = Item.find(message.item_id)
       transaction = Transaction.find(message.transaction_id)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,6 @@
 <%= link_to 'Edit', edit_event_path(@event), class:'btn waves-effect waves-light' %>
 <%= link_to 'Back', account_events_path(@event.account), class:'btn waves-effect waves-light' %>
+<%= link_to 'Orders', event_orders_path(@event), class:'btn waves-effect waves-light right' %>
 <%= link_to 'Staff', event_assignments_path(@event), class:'btn waves-effect waves-light right' %>
 <div id="feed-icon" class="waves-effect waves-light right">
 <%= link_to event_feed_path(@event) do %>
@@ -34,13 +35,8 @@
     <tr>
       <th>Title</th>
       <th>Type</th>
-      <th>Address</th>
       <th>Latitude</th>
       <th >Longitude</th>
-      <th>Event</th>
-      <th>Current Order</th>
-      <th>Last Order</th>
-      <th colspan="3"></th>
 
     </tr>
   </thead>
@@ -50,12 +46,8 @@
       <tr>
         <td><%= link_to location.title, event_location_path(event_id: @event.id, id: location.id) %></td>
         <td><%= location.loc_type %></td>
-        <td><%= location.address%></td>
         <td><%= location.latitude %></td>
         <td><%= location.longitude %></td>
-        <td><%= location.event.title %></td>
-        <td><%= %></td>
-        <td><%=  %></td>
       </tr>
     <% end %>
 

--- a/app/views/orders/_assign.html.erb
+++ b/app/views/orders/_assign.html.erb
@@ -1,0 +1,22 @@
+<%= form_for [@event, order], url: order_assign_path(event_id:@event.id, id: order.id) do |f| %>
+  <% if order.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(order.errors.count, "error") %> prohibited this order from being assigned:</h2>
+
+      <ul>
+      <% order.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :assigned_to %><br />
+    <%= f.select :assigned_to, options_for_select(crew_members(@event).map{|user|[user.first_name, user.id]})%>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Assign to Order ##{order.id}" %>
+  </div>
+<% end %>

--- a/app/views/orders/orders_by_event.html.erb
+++ b/app/views/orders/orders_by_event.html.erb
@@ -1,21 +1,32 @@
 
 <h2>Event Orders</h2>
+<%= link_to 'Back', event_path(@event), class:'btn waves-effect waves-light right' %>
 
 
 <% @locations.each do |l|  %>
 
-<h4><%= l.title %></h4>
-<hr>
-  <% l.orders.each do |o|%>
-    <% link_to o.id, event_location_order_path(@event, o.location, o)%>
-    <ul>
-      <% o.transactions.each do |t| %>
-        <li>
-          <%= t.qty %> x <%= t.item.product.name %> from <%= @locations.find(t.origin_id).title %> to <%= @locations.find(t.dest_id).title %> <%= link_to 'Assign Order', class:'btn waves-effect waves-light' %>
-        </li>
-      <% end %>
-    </ul>
+  <% if l.orders.where(role: 'transfer').length > 0 %>
+    <h4 class="center"><%= l.title %></h4>
+    <hr>
+    <div class="center">
+      <% l.orders.where(role: 'transfer').each do |o|%>
+        [<%= o.status.upcase %>] <%= link_to "Order ##{o.id}: #{o.message}", event_location_order_path(@event, o.location, o), class: 'center'%>
+        <ul>
+          <% o.transactions.each do |t| %>
+            <li>
+              <%= t.qty %> x <%= t.item.product.name %>
+            </li>
+          <% end %>
+        </ul>
 
+       <% if o.assigned_to == nil %>
+        <%= render 'assign', order: o %>
+        <% else%>
+        <strong>Assigned to: <%= @users.find(o.assigned_to).first_name %></strong>
+        <% end %>
+        <hr>
+      <% end %>
+      </div>
   <% end %>
 <% end %>
 

--- a/app/views/orders/orders_by_event.html.erb
+++ b/app/views/orders/orders_by_event.html.erb
@@ -1,8 +1,21 @@
 
-<%= link_to "New Order", new_event_location_order_path , class: 'btn btn-primary btn-lg' %>
+<h2>Event Orders</h2>
 
 
-<% @orders.each do |order|  %>
+<% @locations.each do |l|  %>
 
-  <h3> <%=link_to order.content, event_location_order_path(event_id: @event.id, location_id: @location.id, id: order.id)%> </h3>
+<h4><%= l.title %></h4>
+<hr>
+  <% l.orders.each do |o|%>
+    <% link_to o.id, event_location_order_path(@event, o.location, o)%>
+    <ul>
+      <% o.transactions.each do |t| %>
+        <li>
+          <%= t.qty %> x <%= t.item.product.name %> from <%= @locations.find(t.origin_id).title %> to <%= @locations.find(t.dest_id).title %> <%= link_to 'Assign Order', class:'btn waves-effect waves-light' %>
+        </li>
+      <% end %>
+    </ul>
+
+  <% end %>
 <% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ get '/events/:event_id/locations/:id/pickup_order' => 'locations#pickup_order', 
 get '/events/:event_id/locations/:id/dropoff_order' => 'locations#dropoff_order', as: 'order_dropoff'
 post '/events/:event_id/locations/:location_id/orders/:id/complete' => 'orders#complete', as: 'order_complete'
 post '/events/:event_id/locations/:location_id/orders/:id/submit' => 'orders#submit', as: 'order_submit'
+patch '/events/:event_id/orders/:id/assign' => 'orders#assign_order', as: 'order_assign'
 post '/events/:event_id/locations/:location_id/orders/:id/pickup/:origin' => 'orders#pickup',as: 'event_location_order_pickup'
 post '/events/:event_id/locations/:location_id/orders/:id/dropoff/:dest' => 'orders#dropoff',as: 'event_location_order_dropoff'
 


### PR DESCRIPTION
- Event orders can be accessed from the Event show page
- If an event has orders of type transfer and is unassigned, a form is available to assign crew members 
- When you click "Assign", it updates the order from "submitted" to "pending" and assigns the user from the form